### PR TITLE
Give `$ROCM_PATH` a default

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install amdsmi
 > 2. Ensure you have `libamd_smi.so` in your system. It's shipped together with ROCm. Search order:
 >    1. `site-packages/amdsmi/libamd_smi.so` (inside the `amdsmi` installation directory; useful for debugging/dev)
 >    2. If environment variable `ROCM_PATH` is set, `$ROCM_PATH/lib/libamd_smi.so`
->    3. If environment variable `ROCM_PATH` is **not** set, `/opt/rocm/lib/libamd_smi.so`
+>    3. (Since 6.2.3) If environment variable `ROCM_PATH` is **not** set, `/opt/rocm/lib/libamd_smi.so`
 
 ## 📦 Versioning
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ pip install amdsmi
 
 > [!IMPORTANT]
 > 1. Ensure your ROCm version matches the `amdsmi` package version. For instance, if you are using ROCm 6.2.1, run `pip install amdsmi==6.2.1`. (See [Versioning](#-versioning) for detais.)
-> 2. Ensure your `ROCM_PATH` environment variable is set correctly. The Python package will look for `libamd_smi.so` inside `ROCM_PATH` on `import amdsmi`.
+> 2. Ensure you have `libamd_smi.so` in your system. Search order:
+>    1. `./libamd_smi.so` (inside current directory)
+>    2. If environment variable `ROCM_PATH` is set, `$ROCM_PATH/lib/libamd_smi.so`
+>    3. If environment variable `ROCM_PATH` is **not** set, `/opt/rocm/lib/libamd_smi.so`
 
 ## 📦 Versioning
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install amdsmi
 > [!IMPORTANT]
 > 1. Ensure your ROCm version matches the `amdsmi` package version. For instance, if you are using ROCm 6.2.1, run `pip install amdsmi==6.2.1`. (See [Versioning](#-versioning) for detais.)
 > 2. Ensure you have `libamd_smi.so` in your system. Search order:
->    1. `./libamd_smi.so` (inside current directory)
+>    1. `site-packages/amdsmi/libamd_smi.so` (inside the `amdsmi` installation directory; useful for debugging/dev)
 >    2. If environment variable `ROCM_PATH` is set, `$ROCM_PATH/lib/libamd_smi.so`
 >    3. If environment variable `ROCM_PATH` is **not** set, `/opt/rocm/lib/libamd_smi.so`
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install amdsmi
 
 > [!IMPORTANT]
 > 1. Ensure your ROCm version matches the `amdsmi` package version. For instance, if you are using ROCm 6.2.1, run `pip install amdsmi==6.2.1`. (See [Versioning](#-versioning) for detais.)
-> 2. Ensure you have `libamd_smi.so` in your system. Search order:
+> 2. Ensure you have `libamd_smi.so` in your system. It's shipped together with ROCm. Search order:
 >    1. `site-packages/amdsmi/libamd_smi.so` (inside the `amdsmi` installation directory; useful for debugging/dev)
 >    2. If environment variable `ROCM_PATH` is set, `$ROCM_PATH/lib/libamd_smi.so`
 >    3. If environment variable `ROCM_PATH` is **not** set, `/opt/rocm/lib/libamd_smi.so`

--- a/scripts/checkout_and_push_tag.sh
+++ b/scripts/checkout_and_push_tag.sh
@@ -31,7 +31,7 @@ function fix_amdsmi_version {
     fi
 
     # Make the wrapper look for `libamd_smi.so` inside `$ROCM_PATH`
-    sed -i 's/libamd_smi_cwd = Path.cwd()/libamd_smi_cwd = Path(os.environ["ROCM_PATH"]) \/ "lib"/g' amdsmi_wrapper.py
+    sed -i 's/libamd_smi_cwd = Path.cwd()/libamd_smi_cwd = Path(os.getenv("ROCM_PATH", "/opt/rocm")) \/ "lib"/g' amdsmi_wrapper.py
 
     # Copy over the license file
     cp ../LICENSE . 


### PR DESCRIPTION
When the `ROCM_PATH` environment variable is not set, we default to `/opt/rocm`. This will apply starting 6.2.3. Discussion in https://github.com/ROCm/amdsmi/issues/8.

CC @dmitrii-galantsev